### PR TITLE
raft: Support null parentId when proposing changes to leader

### DIFF
--- a/modules/common/src/main/kotlin/com/github/davenury/common/Exceptions.kt
+++ b/modules/common/src/main/kotlin/com/github/davenury/common/Exceptions.kt
@@ -12,7 +12,7 @@ class NotValidLeader(val ballotNumber: Int, val messageBallotNumber: Int) : Exce
 
 class HistoryCannotBeBuildException : Exception()
 
-class AlreadyLockedException(acquisition: TransactionAcquisition) : Exception(
+class AlreadyLockedException(val acquisition: TransactionAcquisition) : Exception(
     "We cannot perform your transaction, as another transaction is currently running: $acquisition",
 )
 

--- a/src/main/kotlin/com/github/davenury/ucac/ApplicationUcac.kt
+++ b/src/main/kotlin/com/github/davenury/ucac/ApplicationUcac.kt
@@ -357,7 +357,6 @@ class ApplicationUcac(
             runBlocking {
                 if (config.consensus.isEnabled) {
                     multiplePeersetProtocols.protocols.values.forEach { protocols ->
-                        logger.error("DUPA")
                         protocols.consensusProtocol.begin()
                     }
                 }

--- a/src/test/kotlin/com/github/davenury/ucac/api/MixedChangesSpec.kt
+++ b/src/test/kotlin/com/github/davenury/ucac/api/MixedChangesSpec.kt
@@ -203,7 +203,7 @@ class MixedChangesSpec : IntegrationTestBase() {
             }
         }
 
-    @Test
+    @RetryingTest(3)
     fun `try to execute two following changes in the same time, first 2PC, then Raft`(): Unit =
         runBlocking {
             val firstChange = change(0, 1)
@@ -292,7 +292,7 @@ class MixedChangesSpec : IntegrationTestBase() {
             }
         }
 
-    @RetryingTest(3)
+    @RetryingTest(5)
     fun `try to execute two following changes in the same time (two different peers), first 2PC, then Raft`(): Unit =
         runBlocking {
             val change = change(0, 1)


### PR DESCRIPTION
When `parentId` is `null`, no parent checks should be performed.