### PR TITLE
tests: Fix a flaky test

### DIFF
--- a/src/test/kotlin/com/github/davenury/ucac/api/MixedChangesSpec.kt
+++ b/src/test/kotlin/com/github/davenury/ucac/api/MixedChangesSpec.kt
@@ -296,7 +296,7 @@ class MixedChangesSpec : IntegrationTestBase() {
             }
         }
 
-    @RetryingTest(7)
+    @Test
     fun `try to execute two following changes in the same time (two different peers), first 2PC, then Raft`(): Unit =
         runBlocking {
             val change = change(0, 1)

--- a/src/test/kotlin/com/github/davenury/ucac/api/MixedChangesSpec.kt
+++ b/src/test/kotlin/com/github/davenury/ucac/api/MixedChangesSpec.kt
@@ -310,21 +310,19 @@ class MixedChangesSpec : IntegrationTestBase() {
             listOf(applyEndPhaser, electionPhaser, beforeSendingApplyPhaser, applyConsensusPhaser, apply2PCPhaser)
                 .forEach { it.register() }
 
-            val leaderElected =
-                SignalListener {
-                    electionPhaser.arrive()
-                }
-
             val signalListenersForCohort =
                 mapOf(
+                    Signal.TwoPCOnChangeAccepted to
+                        SignalListener {
+                            beforeSendingApplyPhaser.arrive()
+                        },
                     Signal.TwoPCOnChangeApplied to
                         SignalListener {
                             applyEndPhaser.arrive()
                         },
-                    Signal.ConsensusLeaderElected to leaderElected,
-                    Signal.TwoPCOnChangeAccepted to
+                    Signal.ConsensusLeaderElected to
                         SignalListener {
-                            beforeSendingApplyPhaser.arrive()
+                            electionPhaser.arrive()
                         },
                     Signal.ConsensusFollowerChangeAccepted to
                         SignalListener {


### PR DESCRIPTION
This PR fixes flakiness of `try to execute two following changes in the same time (two different peers), first 2PC, then Raft`.